### PR TITLE
Improve compatibility with Gentoo Linux

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -30,6 +30,9 @@ function setup_duplexer {
     echo going ahead.
   fi
 
+  CUPS_LIB_DIR="/usr/lib/cups"
+  [ -d /usr/libexec/cups ] && [ ! -d /usr/lib/cups ] && CUPS_LIB_DIR="/usr/libexec/cups"
+
   #create dir for files to be printed
   mkdir -p /var/spool/cups/duplex/
   chmod 777 /var/spool/cups/duplex/
@@ -40,22 +43,24 @@ function setup_duplexer {
 
   #permit lp user to run zenity as the user running the installer
   zenity_user=$(logname)
+  [ ! -d /etc/sudoers.d ] && mkdir /etc/sudoers.d
   touch /etc/sudoers.d/lp
   chmod 640 /etc/sudoers.d/lp
   echo '#user	host = (runas user) command' > /etc/sudoers.d/lp
   echo "lp ALL=($zenity_user) NOPASSWD:/usr/bin/zenity" >> /etc/sudoers.d/lp
   chmod 440 /etc/sudoers.d/lp
 
-  cp -rf usr/lib/cups/filter/duplex_print_filter /usr/lib/cups/filter/duplex_print_filter
-  chown root:root /usr/lib/cups/filter/duplex_print_filter
-  chmod 755 /usr/lib/cups/filter/duplex_print_filter
+  cp -rf usr/lib/cups/filter/duplex_print_filter $CUPS_LIB_DIR/filter/duplex_print_filter
+  chown root:root $CUPS_LIB_DIR/filter/duplex_print_filter
+  chmod 755 $CUPS_LIB_DIR/filter/duplex_print_filter
 
-  cp -rf usr/lib/cups/backend/duplex-print /usr/lib/cups/backend/duplex-print
-  chown root:root /usr/lib/cups/backend/duplex-print
-  chmod 700 /usr/lib/cups/backend/duplex-print
-  cp -rf usr/lib/cups/backend/duplex-print /usr/lib/cups/backend-available/duplex-print
-  chown root:root /usr/lib/cups/backend-available/duplex-print
-  chmod 700 /usr/lib/cups/backend-available/duplex-print
+  cp -rf usr/lib/cups/backend/duplex-print $CUPS_LIB_DIR/backend/duplex-print
+  chown root:root $CUPS_LIB_DIR/backend/duplex-print
+  chmod 700 $CUPS_LIB_DIR/backend/duplex-print
+  [ ! -d $CUPS_LIB_DIR/backend-available ] && mkdir $CUPS_LIB_DIR/backend-available
+  cp -rf usr/lib/cups/backend/duplex-print $CUPS_LIB_DIR/backend-available/duplex-print
+  chown root:root $CUPS_LIB_DIR/backend-available/duplex-print
+  chmod 700 $CUPS_LIB_DIR/backend-available/duplex-print
 
   echo "Deleting printer if already exists"
   lpadmin -x Manual_Duplexer_$first_printer
@@ -74,7 +79,9 @@ function setup_duplexer {
 
   sleep 1
 
-  service cups restart
+  service cups restart &> /dev/null
+  rc-service cupsd restart &> /dev/null
+  systemctl restart cups &> /dev/null
 
   #add duplexing printer
   lpadmin -p Manual_Duplexer_$first_printer -E -v duplex-print:$first_printer -P /etc/cups/ppd/Manual_Duplexer_$first_printer.ppd


### PR DESCRIPTION
The directory `/usr/lib/cups` doesn't exist as cups is installed to `/usr/libexec/cups`.
The `sudoers.d` and `backend-available` directories will be created if they don't exist.
Also Gentoo Linux either uses `openrc` or `systemd` as init system so I've added `rc-service cupsd restart` and `systemctl restart cups`.