### PR TITLE
Permament display option, xhost permision autostart. Garuda linux compatibility. Install GUI improvment

### DIFF
--- a/home/.config/autostart/xhost_cups.desktop
+++ b/home/.config/autostart/xhost_cups.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Exec=/usr/bin/xhost +local:cups
+Icon=
+Name=xhost_cups
+Path=
+Terminal=False
+Type=Application

--- a/install.sh
+++ b/install.sh
@@ -155,8 +155,40 @@ function setup_duplexer {
   echo
   echo "Duplexer installed."
   echo
+  #! NOT FINISHED
+
+  echo
+  echo "Do you wish to set up xhost to allow the cups user to access the display?"
+  echo "(Y/N) followed by [ENTER]:"
+  read approve
+
+  if [ $approve == "Y" ]
+  then
+    echo
+    xhost +local:cups
+    echo "
+[Unit]
+Description=My Startup Script
+
+[Service]
+ExecStart=/path/to/your/script.sh
+Type=oneshot
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+    " > /etc/systemd/system/xhost.service
+    echo
+    systemctl daemon-reload
+    systemctl enable xhost.service
+    systemctl start xhost.service
+    else
+    echo
+    echo "Nothing was changed. Maybe use capital Y ?"
+    exit 0
+  fi
   exit 0
-}
+  }
 
 echo
 echo "This script assumes /var/spool/cups/ is the folder used by the printing system."
@@ -181,3 +213,5 @@ then
   echo
   exit 0
 fi
+
+

--- a/install.sh
+++ b/install.sh
@@ -165,30 +165,31 @@ function setup_duplexer {
   #! NOT FINISHED
 
   echo
-  echo "Do you wish to set up xhost to allow the cups user to access the display?"
+  echo "Do you wish to set up xhost to allow the cups user to access the display using a systemd service?"
   echo "(Y/N) followed by [ENTER]:"
-  read approve
+  read -r approve
 
-  if [ $approve == "Y" ]
+  if [ "$approve" == "Y" ]
   then
     echo
-    xhost +local:cups
     echo "
 [Unit]
-Description=My Startup Script
+Description=Allow local user 'cups' to access the X server
 
 [Service]
-ExecStart=/path/to/your/script.sh
-Type=oneshot
-RemainAfterExit=yes
+ExecStart=/usr/bin/xhost +SI:localuser:cups
+Restart=always
+User=$SUDO_USER
+Environment=DISPLAY=:0  # Modify this if necessary
 
 [Install]
 WantedBy=multi-user.target
-    " > /etc/systemd/system/xhost.service
+
+    " > /etc/systemd/system/xhost_cups.service
     echo
     systemctl daemon-reload
-    systemctl enable xhost.service
-    systemctl start xhost.service
+    systemctl enable xhost_cups.service
+    systemctl start xhost_cups.service
     else
     echo
     echo "Nothing was changed. Maybe use capital Y ?"

--- a/install.sh
+++ b/install.sh
@@ -165,31 +165,15 @@ function setup_duplexer {
   #! NOT FINISHED
 
   echo
-  echo "Do you wish to set up xhost to allow the cups user to access the display using a systemd service?"
+  echo "Do you wish to set up xhost to allow the cups user to access the display using the .config/autostart directory?"
+  echo "WARNING: This can compromise Xserver security by allowing cups user group to acces the session"
   echo "(Y/N) followed by [ENTER]:"
   read -r approve
 
   if [ "$approve" == "Y" ]
   then
     echo
-    echo "
-[Unit]
-Description=Allow local user 'cups' to access the X server
-
-[Service]
-ExecStart=/usr/bin/xhost +SI:localuser:cups
-Restart=always
-User=$SUDO_USER
-Environment=DISPLAY=:0  # Modify this if necessary
-
-[Install]
-WantedBy=multi-user.target
-
-    " > /etc/systemd/system/xhost_cups.service
-    echo
-    systemctl daemon-reload
-    systemctl enable xhost_cups.service
-    systemctl start xhost_cups.service
+    cp -rf home/.config/autostart/xhost_cups.desktop /home/"$SUDO_USER"/.config/autostart/xhost_cups.desktop
     else
     echo
     echo "Nothing was changed. Maybe use capital Y ?"

--- a/install.sh
+++ b/install.sh
@@ -70,7 +70,8 @@ log_warning "Setting up a permament display may cause issues with the comunicats
 echo -e "$T_CYAN"
 read -e -r -p "[?]Do you wish to set up a permament display for the comunicats? [y/N]" -i "N" approve
 echo -e "$TF_RESET"
-if [ "$approve" == "Y" ]
+# Cheking for lower case too since we suggest to the user to enter N by making y lower case, this may confuse someone.
+if [ "$approve" == "Y" ] || [ "$approve" == "y" ]
 then
 
 displays=$(

--- a/install.sh
+++ b/install.sh
@@ -81,7 +81,7 @@ fi
 command="export DISPLAY=$chosen_display"
 
 echo "Writing to usr/lib/cups/backend/duplex-print"
-echo "$command" | cat - usr/lib/cups/backend/duplex-print > temp && mv temp usr/lib/cups/backend/duplex-print
+sed -i "2i $command" usr/lib/cups/backend/duplex-print
 
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -66,12 +66,10 @@ read -e -r chosen_printer
 
 # Ask a user about the display they want to use
 log "---"
-
-
-log_question "Do you wish to set up a permament display for the comunicats?"
-log_question "(Y/N) followed by [ENTER]:"
-read -e -r approve
-
+log_warning "Setting up a permament display may cause issues with the comunicats! On some linux distributions it may be neccecery!"
+echo -e "$T_CYAN"
+read -e -r -p "[?]Do you wish to set up a permament display for the comunicats? [y/N]" -i "N" approve
+echo -e "$TF_RESET"
 if [ "$approve" == "Y" ]
 then
 

--- a/install.sh
+++ b/install.sh
@@ -1,19 +1,47 @@
 #!/bin/bash
 # Startup checks
 # Script must be run as user with sudo capabilities
+
+
+# Colors for more readable output
+# Text colors
+T_RED='\e[31m'
+T_GREEN='\e[32m'
+T_YELLOW='\e[33m'
+T_CYAN='\e[36m'
+
+# Text formatting
+TF_RESET='\e[0m'
+TF_BOLD='\e[1m'
+
+
+log() {
+    echo -e "${T_GREEN}[I]$*${TF_RESET}" 
+}
+
+log_error() {
+    echo -e "${T_RED}[Error]$*${TF_RESET}"
+}
+
+log_warning() {
+    echo -e "${T_YELLOW}[Warn]$*${TF_RESET}"
+}
+
+log_question() {
+    echo -e "${T_CYAN}[?]$*${TF_RESET}"
+}
+
 clear
-echo "This script must be run from a limited account with root privileges.".
-echo "Run the installation for every user which need the duplex driver."
-echo
+log "This script must be run from a limited account with root privileges."
+log "Run the installation for every user which need the duplex driver."
 
 if [ $(logname) == root ]; then
-  echo "Don't run this as root"
-  echo ""
+  log_error "Don't run this as root"
+
   exit 1
 fi
 if [ $(whoami) != root ]; then
-  echo "Use sudo to become root."
-  echo ""
+  log_error "Use sudo to become root"
   exit 1
 fi
 
@@ -22,27 +50,27 @@ fi
 # all_users=$(awk -F: '($3>=1000)&&($1!="nobody"){print $1}' /etc/passwd)
 
 all_printers=$(lpstat -s | tail -n +2 | awk '{print $3}' | sed 's/.$//')
+log_question "Type the number of the printer you want to add duplexing capabilities, then type ENTER:"
+log_question "These are your installed printers:"
 
-echo "These are your installed printers:"
-echo
 declare printers_array
 i=0
 for p in $all_printers
 do
   i=$(( $i + 1 ))
-  echo $i. $p
+  log_question "$i. $p"
   printers_array[$i]=$p
 done
-echo
-echo "Type the number of the printer you want to add duplexing capabilities, then type ENTER:"
-echo
-read chosen_printer
+
+read -e -r chosen_printer
 
 # Ask a user about the display they want to use
+log "---"
 
-echo "Do you wish to set up a permament display for the comunicats?"
-echo "(Y/N) followed by [ENTER]:"
-read -r approve
+
+log_question "Do you wish to set up a permament display for the comunicats?"
+log_question "(Y/N) followed by [ENTER]:"
+read -e -r approve
 
 if [ "$approve" == "Y" ]
 then
@@ -56,31 +84,28 @@ displays=$(
   }'
 )
 # iterate through the display numbers and print them out
-echo "These are your displays: "
+log_question "Select the display you want to use [number][ENTER]: "
 declare displays_array
 i=0
 for d in $displays
 do
   i=$(( i + 1 ))
-  echo $i. "$d"
+  log_question " $i. $d"
   displays_array[i]=$d
 done
 
-echo
-echo "Type the number of the display you want to show the popups to, then type ENTER:"
-echo
-read -r chosen_display
+read -e -r chosen_display
 
 display=${displays_array[$chosen_display]}
 if [ -z "$display" ]
 then
-  echo "No display selected. You trickster!"
+  log_error "No display selected, you trickster!"
   exit 1
 fi
 
 command="export DISPLAY=$display"
 
-echo "Writing to usr/lib/cups/backend/duplex-print"
+log "Writing to usr/lib/cups/backend/duplex-print"
 sed -i "2i $command" usr/lib/cups/backend/duplex-print
 
 fi
@@ -91,11 +116,11 @@ function setup_duplexer {
   first_printer=$1
   if [ -z "$first_printer" ]
   then
-    echo "No printer submitted. You trickster!"
+    log_error "No printer selected, you trickster!"
     exit 1
   else
-    echo "found printer: "$first_printer
-    echo going ahead.
+    log "Found printer: $first_printer"
+    log "Setting up duplexer"
   fi
 
   CUPS_LIB_DIR="/usr/lib/cups"
@@ -134,7 +159,7 @@ function setup_duplexer {
   chown root:root $CUPS_LIB_DIR/backend-available/duplex-print
   chmod 700 $CUPS_LIB_DIR/backend-available/duplex-print
 
-  echo "Deleting printer if already exists"
+  log "Deleteing if already exists"
   lpadmin -x Manual_Duplexer_$first_printer
 
   cp -praf /etc/cups/ppd/$first_printer.ppd /etc/cups/ppd/Manual_Duplexer_$first_printer.ppd
@@ -159,50 +184,37 @@ function setup_duplexer {
   lpadmin -p Manual_Duplexer_$first_printer -E -v duplex-print:$first_printer -P /etc/cups/ppd/Manual_Duplexer_$first_printer.ppd
   lpadmin -d Manual_Duplexer_$first_printer
 
-  echo
-  echo "Duplexer installed."
-  echo
-  #! NOT FINISHED
 
-  echo
-  echo "Do you wish to set up xhost to allow the cups user to access the display using the .config/autostart directory?"
-  echo "WARNING: This can compromise Xserver security by allowing cups user group to acces the session"
-  echo "(Y/N) followed by [ENTER]:"
-  read -r approve
+  log "Duplexer installed"
+  log_question "Do you wish to set up xhost to allow the cups user to access the display using the .config/autostart directory? [Y/N][ENTER]"
+  log_warning "This can compromise Xserver security by allowing cups user group to acces the session"
+  
+  read -e -r approve
 
   if [ "$approve" == "Y" ]
   then
-    echo
     cp -rf home/.config/autostart/xhost_cups.desktop /home/"$SUDO_USER"/.config/autostart/xhost_cups.desktop
     else
-    echo
-    echo "Nothing was changed. Maybe use capital Y ?"
+    log_error "Nothing was changed. Maybe use capital Y?"
     exit 0
   fi
   exit 0
   }
 
-echo
-echo "This script assumes /var/spool/cups/ is the folder used by the printing system."
-echo
-echo "The script will add"
-echo "                        $first_printer "
-echo
-echo " printer with the duplex setup. Is this what you want?"
-echo
-echo "(Y/N) followed by [ENTER]:"
-read approve
+log "This script assumes /var/spool/cups/ is the folder used by the printing system"
+log_question "The script will add"
+log_question "  ${TF_BOLD}$first_printer"
+log_question "printer with the duplex setup. Is this what you want?"
+log_question "(Y/N) followed by [ENTER]:"
+read -e -r approve
 
 if [ $approve == "Y" ]
 then
-  echo
-  echo
-  echo
     setup_duplexer $first_printer
   else
-  echo
-  echo "Nothing was changed. Maybe use capital Y ?"
-  echo
+
+  log_error "Nothing was changed. Maybe use capital Y?"
+
   exit 0
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -78,7 +78,7 @@ then
   exit 1
 fi
 
-command="export DISPLAY=$chosen_display"
+command="export DISPLAY=$display"
 
 echo "Writing to usr/lib/cups/backend/duplex-print"
 sed -i "2i $command" usr/lib/cups/backend/duplex-print

--- a/install.sh
+++ b/install.sh
@@ -38,6 +38,53 @@ echo "Type the number of the printer you want to add duplexing capabilities, the
 echo
 read chosen_printer
 
+# Ask a user about the display they want to use
+
+echo "Do you wish to set up a permament display for the comunicats?"
+echo "(Y/N) followed by [ENTER]:"
+read -r approve
+
+if [ "$approve" == "Y" ]
+then
+
+displays=$(
+  xdpyinfo | awk '{
+  while (match($0, /[[:space:][:digit:]]:[[:digit:]](\.[[:digit:]])?/)) {
+  print substr($0, RSTART, RLENGTH)
+  $0 = substr($0, RSTART + RLENGTH)
+  }
+  }'
+)
+# iterate through the display numbers and print them out
+echo "These are your displays: "
+declare displays_array
+i=0
+for d in $displays
+do
+  i=$(( i + 1 ))
+  echo $i. "$d"
+  displays_array[i]=$d
+done
+
+echo
+echo "Type the number of the display you want to show the popups to, then type ENTER:"
+echo
+read -r chosen_display
+
+display=${displays_array[$chosen_display]}
+if [ -z "$display" ]
+then
+  echo "No display selected. You trickster!"
+  exit 1
+fi
+
+command="export DISPLAY=$chosen_display"
+
+echo "Writing to usr/lib/cups/backend/duplex-print"
+echo "$command" | cat - usr/lib/cups/backend/duplex-print > temp && mv temp usr/lib/cups/backend/duplex-print
+
+fi
+
 first_printer=${printers_array[$chosen_printer]}
 
 function setup_duplexer {

--- a/usr/lib/cups/backend/duplex-print
+++ b/usr/lib/cups/backend/duplex-print
@@ -67,9 +67,14 @@ elif [ $(( $page_count )) -gt 1 ]; then
 	#show user interface
 	LOG $(date) --- Will Show user interface.
 
-	#export display for zenity to use
-	export DISPLAY=$(who -su | grep $user | awk '$2 ~ /:[0-9.]*/{print $2}')
+  if [ -z "$DISPLAY" ]; then
+    LOG $(date) --- "No display found trying to set one" 
+    #export display for zenity to use
+    export DISPLAY=$(who -su | grep $user | awk '$2 ~ /:[0-9.]*/{print $2}')
+	fi
+
 	LOG $(date) --- Running on display number $DISPLAY
+  xhost +local: #!TAKE A LOOK, THIS IS HACKY FOR ME but it does the job.
 	sudo --user=$user \
 	zenity --question --title="$title" \
         --text="<big><b>Flip and reinsert the entire paper stack when printing has finished,\n\n then press Procceed.</b></big>\n\n\n\n
@@ -85,7 +90,7 @@ elif [ $(( $page_count )) -gt 1 ]; then
 		LOG $(date) --- printing even pages
 		lp -s -d $USE_PRINTER -n "$numcopies" $lp_args -o page-set=even -o collate=true -o outputorder=normal \
 			-o orientation-requested=6 -t "$title"-even "$filename"
-
+  xhost -local:
 
 # UNCOMMENT IF CUPS-FILTERS VERSION IS BELOW 1.0.55
 # Also SET your main printer as default printer

--- a/usr/lib/cups/backend/duplex-print
+++ b/usr/lib/cups/backend/duplex-print
@@ -74,7 +74,6 @@ elif [ $(( $page_count )) -gt 1 ]; then
 	fi
 
 	LOG $(date) --- Running on display number $DISPLAY
-  xhost +SI:localuser:cups #!TAKE A LOOK, THIS IS HACKY FOR ME but it does the job.
 	sudo --user=$user \
 	zenity --question --title="$title" \
         --text="<big><b>Flip and reinsert the entire paper stack when printing has finished,\n\n then press Procceed.</b></big>\n\n\n\n
@@ -90,7 +89,6 @@ elif [ $(( $page_count )) -gt 1 ]; then
 		LOG $(date) --- printing even pages
 		lp -s -d $USE_PRINTER -n "$numcopies" $lp_args -o page-set=even -o collate=true -o outputorder=normal \
 			-o orientation-requested=6 -t "$title"-even "$filename"
-  xhost -SI:localuser:cups
   LOG $(date) --- printing done - removed xhost
 # UNCOMMENT IF CUPS-FILTERS VERSION IS BELOW 1.0.55
 # Also SET your main printer as default printer

--- a/usr/lib/cups/backend/duplex-print
+++ b/usr/lib/cups/backend/duplex-print
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+#!!! THIS LINE(second line) WILL BE OVERWRITTEN BY THE INSTALL SCRIPT !!!
 #TODO:
 # - figure out why and when printer is spitting one blank file.
 #

--- a/usr/lib/cups/backend/duplex-print
+++ b/usr/lib/cups/backend/duplex-print
@@ -1,5 +1,4 @@
 #!/bin/bash
-export DISPLAY=:0
 
 #TODO:
 # - figure out why and when printer is spitting one blank file.

--- a/usr/lib/cups/backend/duplex-print
+++ b/usr/lib/cups/backend/duplex-print
@@ -1,4 +1,5 @@
 #!/bin/bash
+export DISPLAY=:0
 
 #TODO:
 # - figure out why and when printer is spitting one blank file.
@@ -74,7 +75,7 @@ elif [ $(( $page_count )) -gt 1 ]; then
 	fi
 
 	LOG $(date) --- Running on display number $DISPLAY
-  xhost +local: #!TAKE A LOOK, THIS IS HACKY FOR ME but it does the job.
+  xhost +SI:localuser:cups #!TAKE A LOOK, THIS IS HACKY FOR ME but it does the job.
 	sudo --user=$user \
 	zenity --question --title="$title" \
         --text="<big><b>Flip and reinsert the entire paper stack when printing has finished,\n\n then press Procceed.</b></big>\n\n\n\n
@@ -90,8 +91,8 @@ elif [ $(( $page_count )) -gt 1 ]; then
 		LOG $(date) --- printing even pages
 		lp -s -d $USE_PRINTER -n "$numcopies" $lp_args -o page-set=even -o collate=true -o outputorder=normal \
 			-o orientation-requested=6 -t "$title"-even "$filename"
-  xhost -local:
-
+  xhost -SI:localuser:cups
+  LOG $(date) --- printing done - removed xhost
 # UNCOMMENT IF CUPS-FILTERS VERSION IS BELOW 1.0.55
 # Also SET your main printer as default printer
 # SEE https://bugs.launchpad.net/ubuntu/+source/cups-filters/+bug/1340435

--- a/usr/lib/cups/backend/duplex-print
+++ b/usr/lib/cups/backend/duplex-print
@@ -1,5 +1,5 @@
 #!/bin/bash
-#!!! THIS LINE(second line) WILL BE OVERWRITTEN BY THE INSTALL SCRIPT !!!
+
 #TODO:
 # - figure out why and when printer is spitting one blank file.
 #


### PR DESCRIPTION
Resolves #5.

### Check if it will work on your system. I don't know i i did not brake something. 

This adds:
1. A way to setup a permanent display address during installation, to not really on the `who` command which can differ between distributions
2. While installing this allows to set up an autostart script to allow X server access by cups.
3. Install script uses less terminal space and is color coded for user convenience 